### PR TITLE
Fix async event handling and command cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,310 +1,150 @@
-﻿# Chronos Engine v2.0.0
+# Chronos Engine v2.1.0
 
-🚀 **Advanced Calendar Management System with AI-powered optimization**
-
-## ✨ Features
-
-### 📅 Core Features
-- **Smart Calendar Integration** - Mock Google Calendar for development
-- **AI-Powered Optimization** - Intelligent scheduling suggestions  
-- **Advanced Analytics** - Productivity metrics and insights
-- **Conflict Resolution** - Automatic detection and resolution of scheduling conflicts
-- **Time Boxing** - Smart time allocation and focus block suggestions
-- **Plugin System** - Extensible architecture with custom plugins
-
-### 🔧 Technical Features
-- **FastAPI Backend** - High-performance async API
-- **Modern Web Dashboard** - Responsive HTML/CSS/JS interface
-- **Template System** - Jinja2 templates with proper static file handling
-- **Error Handling** - Comprehensive error handling and logging
-- **Task Queue** - Background task processing with retry logic
-- **Mock Services** - Complete mock implementations for development
-
-## 🚀 Quick Start
-
-### Prerequisites
-- Python 3.11+
-- Docker (optional)
-
-### 1. Automated Setup (Recommended)
-```powershell
-.\setup-chronos.ps1
-.\activate.bat
-pip install -r requirements.txt  
-.\start-chronos.bat
-```
-
-### 2. Manual Setup
-```bash
-# Create virtual environment
-python -m venv venv
-source venv/bin/activate  # Linux/Mac
-# or
-venv\Scripts\activate     # Windows
-
-# Install dependencies
-pip install -r requirements.txt
-
-# Run application
-python -m src.main
-```
-
-### 3. Docker Setup
-```bash
-docker-compose up --build
-```
-
-## 📱 Access Points
-
-Once started, access these URLs:
-
-- **🌐 Dashboard**: http://localhost:8080/
-- **📚 API Documentation**: http://localhost:8080/docs  
-- **💓 Health Check**: http://localhost:8080/sync/health
-- **🔄 Manual Sync**: POST http://localhost:8080/sync/calendar
-
-## 🎯 Core Components
-
-### Calendar Management
-```python
-# Sync calendar events
-POST /sync/calendar
-{
-  "days_ahead": 7,
-  "force_refresh": true
-}
-
-# Get events with filters
-GET /api/v1/events?priority_filter=HIGH&limit=50
-```
-
-### AI Optimization  
-```python
-# Get schedule optimization suggestions
-POST /api/v1/ai/optimize
-{
-  "optimization_window_days": 7,
-  "auto_apply": false
-}
-
-# Create time boxes
-POST /api/v1/ai/timebox
-{
-  "target_date": "2025-01-15T00:00:00",
-  "strategy": "priority_first"  
-}
-```
-
-### Analytics
-```python
-# Productivity metrics
-GET /api/v1/analytics/productivity?days_back=30
-
-# Generate comprehensive report  
-GET /api/v1/analytics/report
-# Returns task_id for background processing
-
-# Check task status
-GET /api/v1/tasks/{task_id}
-```
-
-## 🔌 Plugin Development
-
-Create custom plugins by extending base classes:
-
-```python
-# plugins/custom/my_plugin.py
-from src.core.plugin_manager import EventPlugin
-
-class MyPlugin(EventPlugin):
-    @property
-    def name(self) -> str:
-        return "my_custom_plugin"
-        
-    async def process_event(self, event):
-        # Your custom logic here
-        event.tags.append("processed")
-        return event
-```
-
-## 📊 Configuration
-
-Edit `config/chronos.yaml`:
-
-```yaml
-api:
-  host: "0.0.0.0"
-  port: 8080
-  api_key: "your-secure-key"
-
-scheduler:
-  sync_interval: 300  # seconds
-  
-analytics:
-  cache_dir: "data/analytics"
-  
-plugins:
-  enabled: ["sample_event_plugin", "sample_scheduling_plugin"]
-  custom_dir: "plugins/custom"
-```
-
-Environment variables in `.env`:
-```bash
-CHRONOS_API_KEY=your-secure-api-key
-LOG_LEVEL=INFO
-TZ=UTC
-CHRONOS_WEBHOOK_URL=https://your-webhook-url.com
-```
-
-## 🧪 Testing
-
-```bash
-# Run tests
-pytest tests/
-
-# Run specific test
-pytest tests/unit/test_models.py
-
-# Test with coverage
-pytest --cov=src tests/
-```
-
-## 🐳 Docker Production
-
-```bash
-# Production build
-docker-compose -f docker-compose.yml -f docker-compose.prod.yml up --build
-
-# Check health
-curl http://localhost:8080/sync/health
-```
-
-## 📁 Project Structure
-
-```
-chronos-engine/
-├── src/                    # Source code
-│   ├── core/              # Core business logic
-│   │   ├── models.py      # Data models
-│   │   ├── calendar_client.py  # Calendar integration
-│   │   ├── analytics_engine.py # Analytics & metrics
-│   │   ├── ai_optimizer.py     # AI optimization
-│   │   └── ...
-│   ├── api/               # REST API
-│   │   ├── routes.py      # API endpoints
-│   │   ├── dashboard.py   # Web dashboard
-│   │   └── exceptions.py  # Error handling
-│   └── main.py            # Application entry point
-├── templates/             # Jinja2 templates
-├── static/                # CSS, JS, images
-├── plugins/               # Custom plugins
-├── tests/                 # Test suite
-├── config/                # Configuration files
-├── data/                  # Data storage
-└── logs/                  # Application logs
-```
-
-## 🔍 Troubleshooting
-
-### Common Issues
-
-**Port already in use:**
-```bash
-# Change port in config/chronos.yaml or use environment variable
-export CHRONOS_PORT=8081
-```
-
-**Template not found:**
-```bash
-# Ensure templates directory exists
-mkdir -p templates static/css static/js
-```
-
-**Mock calendar not working:**
-```bash
-# Check logs/chronos.log for details
-# Mock service creates sample events automatically
-```
-
-**CSS/JS not loading:**
-```bash
-# Verify static files are mounted correctly
-# Check browser developer console for 404 errors
-```
-
-### Development Tips
-
-1. **Enable debug mode:**
-   ```bash
-   export LOG_LEVEL=DEBUG
-   ```
-
-2. **Reset mock data:**
-   ```python
-   # In Python console
-   from src.core.calendar_client import GoogleCalendarClient
-   client = GoogleCalendarClient("", "")
-   client.reset_mock_events()
-   ```
-
-3. **Check system status:**
-   ```bash
-   curl http://localhost:8080/sync/status
-   ```
-
-## 🤝 Contributing
-
-1. Fork the repository
-2. Create feature branch: `git checkout -b feature-name`
-3. Make changes and add tests
-4. Run tests: `pytest tests/`
-5. Commit: `git commit -m 'Add feature'`
-6. Push: `git push origin feature-name`
-7. Create Pull Request
-
-## 📄 API Reference
-
-Full API documentation available at `/docs` when running.
-
-### Key Endpoints
-
-| Endpoint | Method | Description |
-|----------|--------|-------------|
-| `/` | GET | Web dashboard |
-| `/api/v1/events` | GET/POST | Event management |
-| `/api/v1/analytics/productivity` | GET | Productivity metrics |
-| `/api/v1/ai/optimize` | POST | AI optimization |
-| `/sync/calendar` | POST | Manual sync |
-| `/sync/health` | GET | Health check |
-
-## 🏆 Performance
-
-- **Memory Usage**: ~100MB baseline
-- **Startup Time**: <10 seconds  
-- **Response Time**: <200ms average
-- **Concurrent Users**: 100+ supported
-- **Event Processing**: 1000+ events/minute
-
-## 🔒 Security
-
-- API key authentication
-- CORS protection
-- Input validation
-- SQL injection prevention
-- XSS protection
-- Rate limiting (configurable)
-
-## 📝 License
-
-MIT License - see LICENSE file for details.
-
-## 🆘 Support
-
-- **Documentation**: http://localhost:8080/docs
-- **Health Check**: http://localhost:8080/sync/health
-- **Logs**: Check `logs/chronos.log`
-- **Issues**: Create GitHub issue with logs and steps to reproduce
+Chronos Engine is an async FastAPI service that keeps calendars, templates and command workflows in sync with a SQLite database.  
+The project ships with a scheduler that can pull data from Google Calendar (real OAuth or mocked), normalize it into the local store, run it through plugins (including the command handler), and expose the result through a modern API and dashboard.
 
 ---
 
-**Chronos Engine** - Intelligent Calendar Management for Modern Productivity
+## 🚀 Highlights
+- **FastAPI + Async SQLAlchemy** – non-blocking API backed by SQLite (`data/chronos.db`) with UTC-indexed columns for fast range queries.
+- **Pluggable scheduler** – fetches external events, parses them, runs plugins (command handler, analytics, wellness, …) and persists results.
+- **Advanced event queries** – `/api/v1/events` supports pagination, time-window filtering, text search and calendar scoping.
+- **Template & command workflow** – manage reusable templates, record template usage, and deliver commands to external systems via a queue with completion/failure callbacks.
+- **Operations ready** – `/health` verifies database access, FTS availability and scheduler state; API key protection is enabled for all mutating and sensitive endpoints.
+
+---
+
+## 🏗️ Architecture Overview
+1. **Scheduler (`src/core/scheduler.py`)** pulls calendar events, invokes the plugin pipeline and persists every event (including UTC timestamps) through the `DatabaseService`.
+2. **Database layer (`src/core/database.py`)** provides async sessions and schema creation for events, templates, analytics data, commands and notes.
+3. **API routers (`src/api/…`)** expose CRUD endpoints for events, templates, commands and manual synchronization. The enhanced router contains the advanced filtering logic and command lifecycle endpoints.
+4. **Plugins (`plugins/custom/…`)** extend the system – the command handler translates calendar entries into actionable commands and removes them once consumed.
+5. **Dashboard & client** assets live in `templates/` and `static/` and can be served from the running FastAPI app.
+
+---
+
+## ⚙️ Getting Started
+
+### Prerequisites
+- Python 3.11+
+- (Optional) Docker & Docker Compose if you prefer containers
+
+### Local Setup
+```bash
+# 1. Create and activate a virtual environment
+python -m venv .venv
+source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+
+# 2. Install dependencies
+pip install -r requirements.txt
+
+# 3. Start the API (reads config/chronos.yaml)
+python -m src.main
+```
+The server listens on `http://0.0.0.0:8080` by default. Logs are written to `logs/chronos.log` and the SQLite database is stored in `data/chronos.db`.
+
+### Docker
+```bash
+docker-compose up --build
+```
+This builds the application image, mounts the project files and exposes the API on port `8080`.
+
+---
+
+## 🔐 Configuration & Secrets
+Configuration lives in `config/chronos.yaml`. Important sections:
+- `api.api_key` – bearer token required for most endpoints (default: `development-key-change-in-production`).
+- `calendar.credentials_file` / `token_file` – point to Google OAuth/service-account credentials. If the files are missing the client falls back to the mock calendar implementation.
+- `plugins` – enable/disable plugins and set the custom directory (defaults to `plugins/custom`).
+- `command_handler.action_whitelist` – allow-listed command keywords that the command plugin can emit.
+
+Override values via environment variables when running in production (e.g. `export CHRONOS_API_KEY="super-secret"`).
+
+---
+
+## 🌐 API Surface
+All protected endpoints expect `Authorization: Bearer <api_key>`.
+
+### Health & status
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/health` | GET | Full system check (database connectivity, FTS tables, scheduler health). |
+| `/api/v1/sync/health` | GET | Lightweight scheduler heartbeat (no auth required). |
+
+### Events & templates
+| Endpoint | Method | Notes |
+| --- | --- | --- |
+| `/api/v1/events` | GET | Advanced filtering (calendar, anchor date, range, direction, full-text `q`, pagination). |
+| `/api/v1/events` | POST | Create an event via the scheduler (runs through plugins and persists to SQLite). |
+| `/api/v1/templates` | GET/POST/PUT/DELETE | Manage reusable event templates with ranking and metadata updates. |
+| `/api/v1/templates/{template_id}/use` | POST | Record template usage for analytics. |
+
+### Command queue
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/api/v1/commands/{system_id}` | GET | Poll commands for a target system (resets stale `PROCESSING` items before delivery). |
+| `/api/v1/commands/{command_id}/complete` | POST | Mark a command as completed. |
+| `/api/v1/commands/{command_id}/fail` | POST | Report a failure with an error message and optional retry instructions. |
+
+### Synchronisation & analytics
+| Endpoint | Method | Description |
+| --- | --- | --- |
+| `/api/v1/sync/calendar` | POST | Trigger a manual calendar sync via the scheduler. |
+| `/api/v1/analytics/productivity` | GET | Placeholder productivity metrics (requires analytics engine). |
+| `/api/v1/ai/optimize` | POST | Request optimization suggestions from the AI optimizer module. |
+
+Interactive API docs are available at `http://localhost:8080/docs` once the service is running.
+
+---
+
+## 🧠 Scheduler & Plugin Workflow
+1. Fetch events from Google Calendar (real API when configured, mock data otherwise).
+2. Parse raw events into `ChronosEvent` domain objects.
+3. Run each event through the plugin pipeline. The command handler can turn specially formatted events into actionable commands; when a plugin consumes an event it is removed from SQLite and the external calendar.
+4. Persist remaining events with UTC-normalized timestamps and analytics metadata.
+5. Background tasks (timeboxing, re-planning, analytics) leverage the stored data via async sessions.
+
+Custom plugins can be added under `plugins/custom/` by subclassing `EventPlugin` or `SchedulingPlugin` from `src/core/plugin_manager.py`.
+
+---
+
+## 🗄️ Data & Persistence
+- Primary database: SQLite file at `data/chronos.db` (created automatically).
+- Tables defined in `src/core/models.py` (events, analytics data, templates, template usage, commands, notes, URL payloads, tasks).
+- Async sessions obtained through `db_service.get_session()` to ensure proper cleanup in request handlers and background jobs.
+
+---
+
+## 🧪 Tests
+Run the test suite with:
+```bash
+pytest
+```
+Use `pytest tests/unit/test_event_parser.py::TestEventParser` (or similar) to execute a single test module.
+
+---
+
+## 📁 Project Layout
+```
+src/
+├── api/             # FastAPI routers, schemas and dashboard handlers
+├── core/            # Scheduler, models, plugins, analytics, AI, database helpers
+├── database/        # Additional DB models (e.g. pending sync state)
+├── config/          # Runtime configuration loading
+└── main.py          # FastAPI application factory & lifespan hooks
+plugins/custom/      # Built-in plugins (command handler, wellness monitor, ...)
+templates/           # Dashboard and GUI client templates
+static/              # Front-end assets for the dashboard/client
+```
+
+---
+
+## 🛠️ Troubleshooting
+- **Authorization errors** – ensure the `Authorization` header matches `api.api_key` in `config/chronos.yaml`.
+- **Google Calendar authentication** – add OAuth or service account credentials; without them the client runs in mock mode and serves sample events.
+- **Database issues** – delete `data/chronos.db` for a clean slate, then restart the API to recreate tables.
+- **Static assets missing** – confirm the `templates/` and `static/` directories are present before launching the app.
+
+---
+
+**Chronos Engine** – production-ready calendar orchestration with plugin-driven automation.


### PR DESCRIPTION
## Summary
- update the enhanced events endpoint to use async SQLAlchemy queries and build filters safely
- reset stale command polling jobs and normalize event persistence to rely on calendar event ids
- populate UTC fields when persisting Chronos events and remove command events from the database and calendar when consumed
- fix the health check to use async session context managers and async SQLAlchemy queries for database/fts checks
- refresh the README to document Chronos Engine v2.1 features, setup, API surface and plugin workflow

## Testing
- pytest *(fails: /workspace/TPM/pytest.ini:1: no section header defined)*

------
https://chatgpt.com/codex/tasks/task_e_68cd53decbf48320b593d8b549c09be5